### PR TITLE
Change how severity is read, add code to end of message, ensure error line >=0

### DIFF
--- a/jshint-server/src/server.ts
+++ b/jshint-server/src/server.ts
@@ -61,6 +61,10 @@ interface JSHINT {
 }
 
 function makeDiagnostic(problem: JSHintError): Diagnostic {
+	//setting errors (and potentially global file errors) will report on line zero, char zero.
+	//ensure that the start and end are >=0 (gets dropped by one in the return)
+	if (problem.line<=0 ) problem.line = 1;
+	if (problem.character<=0 ) problem.character = 1;
 	return {
 		//also report the code at the end of the message, makes it easier to turn on/off
 		//if the user wants to ignore it

--- a/jshint-server/src/server.ts
+++ b/jshint-server/src/server.ts
@@ -62,7 +62,9 @@ interface JSHINT {
 
 function makeDiagnostic(problem: JSHintError): Diagnostic {
 	return {
-		message: problem.reason,
+		//also report the code at the end of the message, makes it easier to turn on/off
+		//if the user wants to ignore it
+		message: problem.reason+(problem.code?" ("+problem.code+")":""),
 		severity: getSeverity(problem),
 		code: problem.code,
 		range: {
@@ -73,7 +75,12 @@ function makeDiagnostic(problem: JSHintError): Diagnostic {
 }
 
 function getSeverity(problem: JSHintError): number {
-	if (problem.id === '(error)') {
+	//this isn't right: JSHint always reports the id as an error.
+	//we need to look at the first letter of the code for that
+	//if there is no code (that would be very odd) we'll push it as an error as well.
+	//See http://jshint.com/docs/ (search for error. It is only mentioned once.)
+	//if (problem.id === '(error)') {
+	if (!problem.code || problem.code[0] === 'E') {
 		return DiagnosticSeverity.Error;
 	}
 	return DiagnosticSeverity.Warning;


### PR DESCRIPTION
Currently the extension reports every problem as an error. Where the severity is being read always contains the `"(error)"` value. The severity is reported as the first character of the problem code (**`W`** or **`E`**. This request makes a change to check that letter instead.

Also adds the problem code in brackets after the message. Helps the user to set individual warnings to be ignored if needed. Also helps search for a better description on [JSLint Error Explanations](https://jslinterrors.com/).