### PR TITLE
Add support for "extends". Fixes #13.

### DIFF
--- a/jshint-server/src/server.ts
+++ b/jshint-server/src/server.ts
@@ -164,14 +164,53 @@ class OptionsResolver {
 			return result;
 		};
 
-		function readJsonFile(file: string): any {
+		function readJsonFile(file: string, extendedFrom?: string): any {
 			try {
 				return JSON.parse(stripComments(fs.readFileSync(file).toString()));
 			}
 			catch (err) {
-				that.connection.window.showErrorMessage(`Can't load JSHint configuration from file ${file}. Please check the file for syntax errors.`);
+				let location = extendedFrom ? `${file} extended from ${extendedFrom}` : file;
+				that.connection.window.showErrorMessage(`Can't load JSHint configuration from file ${location}. Please check the file for syntax errors.`);
 				return {};
 			}
+		}
+
+		function isArray(value: any): boolean {
+			return Array.isArray(value);
+		}
+
+		function isPlainObject(value: any): boolean {
+			return (typeof value === 'object') && !isArray(value);
+		}
+
+		function merge(parent: any, child: any): any {
+			for (let key in child) {
+				if (isPlainObject(parent[key]) && isPlainObject(child[key])) {
+					merge(parent[key], child[key]);
+				} else if (isArray(parent[key]) && isArray(child[key])) {
+					parent[key] = parent[key].concat(child[key]);
+				} else {
+					parent[key] = child[key];
+				}
+			}
+
+			return parent;
+		}
+
+		function readJSHintFile(file: string, extendedFrom?: string): any {
+			let content = readJsonFile(file, extendedFrom);
+			if (content.extends) {
+				let baseFile = path.resolve(path.dirname(file), content.extends);
+
+				if (fs.existsSync(baseFile)) {
+					content = merge(readJSHintFile(baseFile, file), content);
+				} else {
+					that.connection.window.showErrorMessage(`Can't find JSHint file ${baseFile} extended from ${file}`);
+				}
+
+				delete content.extends;
+			}
+			return content;
 		}
 
 		function isWindows(): boolean {
@@ -198,7 +237,7 @@ class OptionsResolver {
 
 			let configFile = locateFile(fsPath, JSHINTRC);
 			if (configFile) {
-				return readJsonFile(configFile);
+				return readJSHintFile(configFile);
 			}
 		}
 
@@ -206,7 +245,7 @@ class OptionsResolver {
 		if (home) {
 			let file = path.join(home, JSHINTRC);
 			if (fs.existsSync(file)) {
-				return readJsonFile(file);
+				return readJSHintFile(file);
 			}
 		}
 		return jshintOptions;


### PR DESCRIPTION
This change adds support for the `extends` option. The `extends` option specifies another `.jshintrc` file to use as the base configuration. It's listed [in the JSHint CLI documentation](http://jshint.com/docs/cli/).

The actual implementation of this option in jshint uses [_.merge](https://lodash.com/docs#merge). However, since this extension doesn't have any third-party dependencies, I wasn't sure if I should add a dependency on lodash. I instead implemented a `merge` function.

This option can only be specified in a `.jshintrc` file.