### PR TITLE
Added default types to configuration properties. Fixes type error in …

### DIFF
--- a/jshint/package.json
+++ b/jshint/package.json
@@ -38,7 +38,7 @@
 					"description": "Control whether or not jshint is enabled for JavaScript files."
 				},
 				"jshint.config" : {
-					"type": "string",
+					"type": ["string", "null"],
 					"default": null,
 					"description": "A path to file containing the configuration options for jshint. If the file exists it overrides jshint.options and any .jshintrc file"
 				},
@@ -48,7 +48,7 @@
 					"description": "The jshint options object to provide args to the jshint command."
 				},
 				"jshint.excludePath": {
-					"type": "string",
+					"type": ["string", "null"],
 					"default": null,
 					"description": "A path to a file containing patterns describing which files and directories should be ignored by jshint. If the file exists it overrides jshint.exclude and any .jshintignore file."
 				},


### PR DESCRIPTION
…VSCode when opening settings.json

Referenced [this issue](https://github.com/Microsoft/vscode-go/issues/196) when fixing this bug.
