### PR TITLE
add lintExt opt and consume in validate

### DIFF
--- a/jshint-server/src/server.ts
+++ b/jshint-server/src/server.ts
@@ -48,6 +48,7 @@ interface JSHintSettings {
 	exclude: FileSettings;
 	reportWarningsAsErrors: boolean;
 	lintHTML: boolean;
+	lintExt: array;
 }
 
 interface Settings {
@@ -558,7 +559,8 @@ class Linter {
 	}
 
 	private async validate(document: TextDocument): Promise<void> {
-		if (!this.settings.lintHTML && document.languageId === "html") {
+		let exts = this.settings.lintExt;
+		if (!this.settings.lintHTML && exts.includes(document.languageId) {
 			// If the setting is toggled, errors need to be cleared
 			this.connection.sendDiagnostics({ uri: document.uri, diagnostics: [] });
 			return;
@@ -572,7 +574,7 @@ class Linter {
 		let diagnostics: Diagnostic[] = [];
 
 		if (!this.fileMatcher.excludes(fsPath, this.workspaceRoot)) {
-			const content = document.languageId === "html" ? this.getEmbeddedJavascript(document.getText()) : document.getText();
+			const content = exts.includes(document.languageId) ? this.getEmbeddedJavascript(document.getText()) : document.getText();
 			let errors = await this.lintContent(content, fsPath);
 			if (errors) {
 				errors.forEach((error) => {

--- a/package.json
+++ b/package.json
@@ -485,6 +485,11 @@
 					"default": false,
 					"description": "Lint JavaScript embedded in HTML"
 				},
+				"jshint.lintExt": {
+					"type": "array",
+					"default": ["html"],
+					"description": "When lintHTML is enabled, lint these file types"
+				},
 				"jshint.nodePath": {
 					"scope": "resource",
 					"type": "string",


### PR DESCRIPTION
- Add `lintExt` opt as companion of `'lintHTML` to enable liniting/extraction of JS in other file types.